### PR TITLE
FIX: spread syntax not running on startup

### DIFF
--- a/frontend/config/next/withResolveAliases.js
+++ b/frontend/config/next/withResolveAliases.js
@@ -6,10 +6,11 @@ module.exports = (nextConfig = {}) =>
         config = nextConfig.webpack(config, options);
       }
 
-      config.resolve.alias = {
-        ...(config.resolve.alias || {}),
-        ...(nextConfig.resolveAliases || {}),
-      };
+      config.resolve.alias = Object.assign(
+        {},
+        config.resolve.alias || {},
+        nextConfig.resolveAliases || {}
+      );
 
       return config;
     },


### PR DESCRIPTION
What is the recommended node version for de development? I started with node v6 then the startup breaks. Now I use v8 that looks like it's working. Maybe we could add a ".nvm" file? But maybe we could use Object.assign anyway to have the out of the box experience also for old node versions better.  With my PR it also works wit v6